### PR TITLE
fix flight mode axes inversion

### DIFF
--- a/KerbTrack/KerbTrack.cs
+++ b/KerbTrack/KerbTrack.cs
@@ -417,7 +417,7 @@ namespace KerbTrack
                                         xp = x * xScale + xOffset;
                                         yp = y * yScale + yOffset;
                                         zp = z * -zScale + zOffset;
-                                        FlightCamera.fetch.transform.localEulerAngles = new Vector3(pv, yv, rv);
+                                        FlightCamera.fetch.transform.localEulerAngles = new Vector3(-pv, -yv, rv);
                                     }
                                     //FlightCamera.fetch.transform.localPosition = new Vector3(xp, yp, zp);
                                     // Without setting the flight camera transform, the pod rotates about without changing the background.


### PR DESCRIPTION
Flight mode yaw and pitch was inverted compared to IVA mode.
This still doesn't fix the fact that flight mode normally only tracks when the escape menu is up, but I have noticed that the FPS EVA mode of the "[through the eyes](https://github.com/linuxgurugamer/Through-The-Eyes)" mod works (apart from the inversion which this PR fixes).